### PR TITLE
Allow buttons to stay registered across rounds

### DIFF
--- a/BUTTON_V5_NEEDS_TEST/BUTTON_V5_NEEDS_TEST.ino
+++ b/BUTTON_V5_NEEDS_TEST/BUTTON_V5_NEEDS_TEST.ino
@@ -30,7 +30,8 @@ const int BUTTON_PIN = 16;
 const int LED_PIN    = 27;
 
 // DIP pins (bit0..bit3)
-constexpr uint8_t DIP_PINS[4] = {19, 18, 5, 17};
+constexpr uint8_t DIP_PINS[] = {19, 18, 5, 17};
+constexpr uint8_t DIP_COUNT = sizeof(DIP_PINS) / sizeof(DIP_PINS[0]);
 constexpr bool DIP_ACTIVE_LOW = true;  // using INPUT_PULLUP -> ON = LOW
 
 // ---------- Hub MAC (update if needed) ----------
@@ -53,13 +54,13 @@ inline void ledOff() { digitalWrite(LED_PIN, LED_ACTIVE_LOW ? HIGH : LOW ); }
 
 // ---------- Read STA MAC into array ----------
 static void getStaMac(uint8_t out[6]) {
-  esp_read_mac(out, ESP_MAC_WIFI_STA);
+  WiFi.macAddress(out);
 }
 
 // ---------- Read DIP as 0..15 ----------
 uint8_t readDip() {
   uint8_t v = 0;
-  for (uint8_t i = 0; i < 4; i++) {
+  for (uint8_t i = 0; i < DIP_COUNT; i++) {
     int s = digitalRead(DIP_PINS[i]);
     if (DIP_ACTIVE_LOW) s = !s; // invert if ON=LOW
     if (s) v |= (1u << i);

--- a/BUTTON_V5_NEEDS_TEST/BUTTON_V5_NEEDS_TEST.ino
+++ b/BUTTON_V5_NEEDS_TEST/BUTTON_V5_NEEDS_TEST.ino
@@ -21,6 +21,12 @@
 
 #include <esp_now.h>
 #include <WiFi.h>
+#if defined(__has_include)
+#  if __has_include(<esp_wifi.h>)
+#    include <esp_wifi.h>
+#    define HAVE_ESP_WIFI 1
+#  endif
+#endif
 
 // ---------- LED polarity ----------
 #define LED_ACTIVE_LOW false   // set true if your LED turns ON when pin is LOW
@@ -55,6 +61,11 @@ inline void ledOff() { digitalWrite(LED_PIN, LED_ACTIVE_LOW ? HIGH : LOW ); }
 
 // ---------- Read STA MAC into array ----------
 static void getStaMac(uint8_t out[6]) {
+#if defined(ESP_PLATFORM) && defined(HAVE_ESP_WIFI)
+  if (esp_wifi_get_mac(WIFI_IF_STA, out) == ESP_OK) {
+    return;
+  }
+#endif
   WiFi.macAddress(out);
 }
 

--- a/HUB_V5_NEEDS_TEST/HUB_V5_NEEDS_TEST.ino
+++ b/HUB_V5_NEEDS_TEST/HUB_V5_NEEDS_TEST.ino
@@ -321,8 +321,7 @@ void finishRound() {
   mode = MODE_IDLE;
   expected_id = 1;
   counted = 0;
-  // Immediately re-open registration for the next round
-  clearPeers();
+  // Immediately re-open registration for the next round while keeping peers
   openRegistrationWindow();
 }
 
@@ -350,7 +349,6 @@ void onDataRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, in
 
       // Start a fresh registration window if currently idle
       if (!reg_open && mode == MODE_IDLE) {
-        clearPeers();
         openRegistrationWindow();
       }
 
@@ -389,7 +387,6 @@ void onDataRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, in
 
       // If we get a press while idle and no window is open, open a window (optional)
       if (mode == MODE_IDLE && !reg_open) {
-        clearPeers();
         openRegistrationWindow();
         // Treat this press as part of the NEXT round; ignore now.
         Serial.println("[Hub] Press arrived; opened registration. Press ignored until round starts.");

--- a/HUB_V5_NEEDS_TEST/HUB_V5_NEEDS_TEST.ino
+++ b/HUB_V5_NEEDS_TEST/HUB_V5_NEEDS_TEST.ino
@@ -57,14 +57,14 @@ enum FeedbackCode : uint8_t {
 // Button -> Hub payloads
 typedef struct __attribute__((packed)) {
   uint8_t kind;       // BTN_REGISTER
-  uint8_t button_id;  // 0..15
+  uint8_t button_id;  // 0..63 (6 DIP switches)
   bool    ffa;        // FFA flag for this device
   uint8_t mac[6];     // device MAC (also available from recv_info)
 } btn_register_t;
 
 typedef struct __attribute__((packed)) {
   uint8_t  kind;       // BTN_PRESS
-  uint8_t  button_id;  // 0..15
+  uint8_t  button_id;  // 0..63
   bool     pressed;    // true on edge
   uint16_t press_id;   // increments per press (per-device)
   uint8_t  mac[6];     // sender MAC (convenience)
@@ -107,7 +107,8 @@ static const int MAX_PEERS = 16;
 static Peer peers[MAX_PEERS];
 
 // Map button_id -> index into peers (for Sequence)
-int idToIndex[16]; // -1 if unmapped
+static const uint8_t MAX_BUTTON_ID = 63; // supports 6 DIP switches (values 0..63)
+int idToIndex[MAX_BUTTON_ID + 1]; // -1 if unmapped
 
 // Find peer slot by MAC (exact match)
 int findPeerByMac(const uint8_t mac[6]) {
@@ -141,15 +142,15 @@ void clearPeers() {
   for (int i = 0; i < MAX_PEERS; i++) {
     peers[i] = Peer{};
   }
-  for (int i = 0; i < 16; i++) idToIndex[i] = -1;
+  for (int i = 0; i <= MAX_BUTTON_ID; i++) idToIndex[i] = -1;
 }
 
 // Build id -> index map for sequence mode
 void rebuildIdMap() {
-  for (int i = 0; i < 16; i++) idToIndex[i] = -1;
+  for (int i = 0; i <= MAX_BUTTON_ID; i++) idToIndex[i] = -1;
   for (int i = 0; i < MAX_PEERS; i++) {
     if (!peers[i].present) continue;
-    if (peers[i].button_id > 0 && peers[i].button_id < 16) {
+    if (peers[i].button_id > 0 && peers[i].button_id <= MAX_BUTTON_ID) {
       idToIndex[peers[i].button_id] = i; // last wins on conflict
     }
   }
@@ -304,7 +305,7 @@ void closeRegistrationAndStartRound() {
     Serial.print("[Hub] Starting SEQUENCE with "); Serial.print(participants); Serial.println(" participants.");
     // Turn all off, then light the first if it exists
     allLedsOff();
-    int idx = (expected_id < 16) ? idToIndex[expected_id] : -1;
+    int idx = (expected_id <= MAX_BUTTON_ID) ? idToIndex[expected_id] : -1;
     if (idx >= 0) {
       sendLedSet(peers[idx].mac, true);
     } else {
@@ -427,10 +428,10 @@ void onDataRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, in
 
           // Advance or finish
           rebuildIdMap(); // ensure map is current if any hot-swap happened
-          int nextIdx = (expected_id < 16) ? idToIndex[expected_id] : -1;
+          int nextIdx = (expected_id <= MAX_BUTTON_ID) ? idToIndex[expected_id] : -1;
           int total   = countPresent();
 
-          if (expected_id <= 15 && nextIdx >= 0) {
+          if (expected_id <= MAX_BUTTON_ID && nextIdx >= 0) {
             // Light next
             sendLedSet(peers[nextIdx].mac, true);
           } else {
@@ -446,7 +447,7 @@ void onDataRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, in
           allLedsOff();
           expected_id = 1;
           rebuildIdMap();
-          int firstIdx = idToIndex[expected_id];
+          int firstIdx = (expected_id <= MAX_BUTTON_ID) ? idToIndex[expected_id] : -1;
           if (firstIdx >= 0) sendLedSet(peers[firstIdx].mac, true);
         }
 


### PR DESCRIPTION
## Summary
- add a reusable helper on the button firmware to resend BTN_REGISTER frames and call it after HUB_ALL_FLASH to prepare the next round
- reuse the helper when DIP switches change or on boot so registration always goes through the same path
- keep hub peers when rounds finish or when reopening registration so buttons can stay enrolled without re-registering

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8455b98c08328a9f00e8efa3a8052